### PR TITLE
[codex] Rename Google Sheets keep tab to Keep

### DIFF
--- a/gsheets_utils.py
+++ b/gsheets_utils.py
@@ -17,6 +17,7 @@ from logging_utils import log_event  # used for structured [GS] log lines
 GS_LIBS_OK = False
 GS_LIB_ERROR = None
 HAVE_GS = False   # new: global flag used elsewhere
+DEFAULT_KEEP_TAB_NAME = "Keep"
 
 try:
     import gspread
@@ -128,7 +129,7 @@ def fetch_prior_decisions(
         creds = Credentials.from_service_account_file(str(key_file), scopes=scopes)
         client = gspread.authorize(creds)
         sh = client.open_by_url(sheet_url)
-        ws = sh.worksheet(tab_name) if tab_name else sh.sheet1
+        ws = sh.worksheet(tab_name or DEFAULT_KEEP_TAB_NAME)
 
         records = ws.get_all_records()
         prior: dict[str, tuple[str, str]] = {}
@@ -164,7 +165,7 @@ def push_results_to_sheets(
     skipped_rows: list[dict],
     keep_fields: list[str],
     skip_fields: list[str],
-    tab_name: str,
+    tab_name: str | None,
     key_path: str | None,
     progress_clear=None,
 ) -> None:
@@ -226,7 +227,7 @@ def push_rows_to_google_sheet(
     sheet_url: str,
     rows: list[dict],
     fields: list[str],
-    tab_name: str,
+    tab_name: str | None,
     key_path: str | None,
     progress_clear=None,
 ) -> None:
@@ -266,7 +267,7 @@ def push_rows_to_google_sheet(
         creds = Credentials.from_service_account_file(str(key_file), scopes=scopes)
         client = gspread.authorize(creds)
         sh = client.open_by_url(sheet_url)
-        ws = sh.worksheet(tab_name) if tab_name else sh.sheet1
+        ws = sh.worksheet(tab_name or DEFAULT_KEEP_TAB_NAME)
 
         if progress_clear:
             progress_clear()

--- a/logging_utils.py
+++ b/logging_utils.py
@@ -58,7 +58,7 @@ def _log(level: str, message: str, *, prefix: str = "") -> None:
     Core logger used by the helpers below.
 
     Example output:
-    [2025-11-21 14:45:10] [INFO                  ].[GS] Pushed 2 rows to tab 'Table1'.
+    [2025-11-21 14:45:10] [INFO                  ].[GS] Pushed 2 rows to tab 'Keep'.
     """
     progress_clear_if_needed()
     ts = _timestamp()

--- a/po_job_scraper.py
+++ b/po_job_scraper.py
@@ -7349,7 +7349,7 @@ MAX_SECONDS_PER_SITE = 60     # hard cap per listing page
 # === Google Sheets push ===
 GS_KEY_PATH = "/Users/ange/job-scraper/service_account.json"   # absolute path to your JSON key
 GS_SHEET_URL = "https://docs.google.com/spreadsheets/d/1UloVHEsBxvMJ3WeQ8XkHvtIrL1cQ2CiyD50bsOb-Up8/edit?gid=1531552984#gid=1531552984"              # full URL to “product jobs scraper”
-GS_TAB_NAME = "Table1"  # or "Sheet1" — match the tab name shown in the bottom-left of the sheet
+GS_TAB_NAME = "Keep"  # match the keep-tab name shown in the bottom-left of the sheet
 # GitHub push control (toggle: "off" | "ask" | "auto")
 #PUSH_MODE = "ask"   # Set to "auto" for automatic pushes, or "off" to disable
 
@@ -12142,7 +12142,7 @@ def _done_box() -> str:
 # =====================================================================
 
 
-KEEP_REASON_FIELD = "Reason"           # lives only in Table1
+KEEP_REASON_FIELD = "Reason"           # lives only in Keep
 SKIP_REASON_FIELD = "Reason Skipped"   # lives only in SKIPPED tab
 
 


### PR DESCRIPTION
## What changed
- renamed the configured Google Sheets keep tab from `Table1` to `Keep`
- updated Google Sheets helper fallbacks to resolve to the explicit `Keep` worksheet instead of the first worksheet
- refreshed stale comments and log examples that still referenced the old tab name

## Why
The keep worksheet is now named `Keep`. The previous fallback behavior depended on worksheet ordering via `sheet1`, which could silently target the wrong tab if the sheet order changed.

## Impact
Google Sheets carry-forward and results push now target the `Keep` worksheet explicitly, reducing the risk of reads or writes landing on the wrong tab.

## Validation
- `python3 -m py_compile po_job_scraper.py gsheets_utils.py logging_utils.py`
- verified that the scraper reports `WorksheetNotFound('Keep')` before the sheet tab is renamed, which is the expected failure mode
- verified that after renaming the tab to `Keep`, rows push successfully to `Keep`
- verified that `Skipped` continues to append rows unchanged
- verified that existing keep-tab records remained intact after renaming `Table1` to `Keep`
- verified that prior `Applied?` and `Reason` values still carry forward correctly

Closes #8